### PR TITLE
added support for more fields from /proc/[pid]/stat; read /proc/self/stat

### DIFF
--- a/htop/Makefile
+++ b/htop/Makefile
@@ -9,7 +9,7 @@ linux_info.o : linux_info.c main.h linux_info.h
 	cc -c linux_info.c
 draw.o : draw.c linux_info.h draw.h
 	cc -c draw.c
-scoket.o : scoket.c scoket.h
+socket.o : socket.c socket.h
 	cc -c socket.c
 log.o : log.c log.h
 	cc -c log.c

--- a/htop/linux_info.h
+++ b/htop/linux_info.h
@@ -90,6 +90,11 @@ typedef struct pid_stats {
   int           sigignore;                /** The bitmap of ignored signals **/
   int           sigcatch;                 /** The bitmap of catched signals **/
   unsigned int  wchan;  /** 33 **/        /** (too long) **/
+  unsigned int  nswap;  /** 34 **/        /** Number of pages swapped **/
+  unsigned int  cnswap;  /** 35 **/        /** Cumulative nswap for child processes **/
+  int  exit_signal;  /** 36 **/   /** Signal to be sent to parent when we die **/
+  int  processor;  /** 37 **/     /** CPU number last executed on **/
+  /** (too long) **/
 		
 } pid_stats;
 typedef struct pid_io
@@ -146,12 +151,15 @@ typedef struct process_list_info
 #define STAT			"/proc/stat"
 #define UPTIME			"/proc/uptime"
 #define PID_STAT	"/proc/%u/stat"
+#define SELF_STAT	"/proc/self/stat"
 #define PID_STATUS	"/proc/%u/status"
 #define PID_IO	"/proc/%u/io"
 #define PID_STATM	"/proc/%u/statm"
-extern void get_memory_info(meminfo *this);
-extern int get_cpu_info(cpuinfo *this);
-extern int get_process_list_info(process_list_info *this);
+
+extern void get_memory_info(meminfo *thisa);
+extern int get_cpu_info(cpuinfo *thisa);
+extern int get_process_list_info(process_list_info *thisa);
 extern void scan(int enable_draw);
 extern void read_uptime(unsigned long long *uptime);
+extern int read_self_stat_info(process_info * thisa);
 #endif


### PR DESCRIPTION
1. more four fields
              (36) nswap  %lu
                        Number of pages swapped (not maintained).

              (37) cnswap  %lu
                        Cumulative nswap for child processes (not maintained).

              (38) exit_signal  %d  (since Linux 2.1.22)
                        Signal to be sent to parent when we die.

              (39) processor  %d  (since Linux 2.2.8)
                        CPU number last executed on.

2. to read /proc/self/stat, instead of only based on pid